### PR TITLE
Allow receipt of multiple capabilities in a single capability option

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,8 @@ Revision history for Perl extension Net::BGP.
           array reference form, but code didn't.  Added support to code for
           new ASPaths to be specified by array references (they create an
           AS_SEGMENT now, as expected from docs).
+        - Bugfix: Support receipt of multiple capabilities in a single open
+          message (BIRD requires this).
 
 0.15    2014-12-18
         - Add configuration for whether or not to send capability

--- a/lib/Net/BGP/Transport.pm
+++ b/lib/Net/BGP/Transport.pm
@@ -1337,17 +1337,27 @@ sub _decode_capabilities
 
     $this->{'_peer_refresh'} = TRUE;
 
-    if (length($value) < 2) {
-        $this->_error(BGP_ERROR_CODE_OPEN_MESSAGE,
-            BGP_ERROR_SUBCODE_BAD_OPT_PARAMETER);
+    while (length($value) > 0) {
+
+        if (length($value) < 2) {
+            $this->_error(BGP_ERROR_CODE_OPEN_MESSAGE,
+                BGP_ERROR_SUBCODE_BAD_OPT_PARAMETER);
+            return;
+        }
+
+        my ($type, $len) = unpack('cc', substr($value, 0, 2));
+        my $data = substr($value, 2, $len);
+
+        $this->_decode_one_capability($type, $len, $data);
+
+        $value = substr($value, 2+$len);
     }
 
-    my ($type, $len) = unpack('cc', substr($value, 0, 2));
+}
 
-    my $data = '';
-    if (length($value) > 2) {
-       $data = substr($value, 2);
-    }
+sub _decode_one_capability {
+    my ($this, $type, $len, $data) = @_;
+
     if (length($data) != $len) {
         $this->_error(BGP_ERROR_CODE_OPEN_MESSAGE,
             BGP_ERROR_SUBCODE_BAD_OPT_PARAMETER);

--- a/t/32-Open.t
+++ b/t/32-Open.t
@@ -1,0 +1,45 @@
+#!/usr/bin/perl -wT
+
+use strict;
+
+use Test::More tests => 10;
+
+# Use
+use_ok('Net::BGP');
+
+# Build the objects
+use_ok('Net::BGP::Process');
+my $bgp = Net::BGP::Process->new();
+ok(ref $bgp eq 'Net::BGP::Process', 'Net::BGP::Process constructor');
+
+use_ok('Net::BGP::Peer');
+my $peer = Net::BGP::Peer->new(
+    Start      => 0,
+    ThisID     => '1.2.3.4',
+    ThisAS     => '1',
+    PeerID     => '127.0.0.1',
+    PeerAS     => '200000',
+    SupportAS4 => 1,
+    Listen     => 0,
+    Passive    => 1
+);
+ok(ref $peer eq 'Net::BGP::Peer', 'Net::BGP::Peer constructor');
+
+my $transport = new Net::BGP::Transport(parent => $peer);
+ok(ref $transport eq 'Net::BGP::Transport', 'sNet::BGP::Transport constructor');
+
+my @msg = qw(
+  04 5B A0 00  F0 CC DD EE  FF 10 02 0E
+  01 04 00 01  00 01 02 00  41 04 00 03
+  0D 40
+);
+
+my $ret =
+  $transport->_decode_bgp_open_message(join('', map { pack('H2', $_); } @msg));
+ok($ret, "Decode BGP OPEN with multi-capability in one option");
+
+ok($transport->can_refresh, "Refresh properly decoded");
+ok($transport->can_as4,     "AS4 properly decoded");
+ok($transport->can_mbgp,    "MBGP properly decoded");
+
+__END__


### PR DESCRIPTION
This fixes the problem I mentioned with capability announcements.  Some BGP speakers (Cisco, Juniper, etc) use multiple capability options with a single capability per option, while others (BIRD) use multiple capabilities per option.  I modified the Changes file to assume this would go into .16.